### PR TITLE
fix push info badge default value bug

### DIFF
--- a/lib/igetui/template/base_template.rb
+++ b/lib/igetui/template/base_template.rb
@@ -62,7 +62,7 @@ module IGeTui
       @push_info.message = ''
       @push_info.actionKey = ''
       @push_info.sound = ''
-      @push_info.badge = ''
+      @push_info.badge = '-1'
       @push_info
     end
 


### PR DESCRIPTION
First, I'm very thankful to you for this repository for giving me much convinience.
But I found that when I want to push a transmission message without apns notification, it always make a sound.
I looked into official python documents api, and found that this file igt_base_template.py:

```
def getPushInfo(self):
    if self.pushInfo is None:
        self.pushInfo = gt_req_pb2.PushInfo()
        self.pushInfo.message = ""
        self.pushInfo.actionKey = ""
        self.pushInfo.sound = ""
        self.pushInfo.badge = "-1"
    return self.pushInfo
```

I edit it and it works. no sound any more.
I also compare the params['clientData"'] in http post request, and it is the same.
I wish that what I edit is just right. So may you take a look at it?
